### PR TITLE
Minor fix.

### DIFF
--- a/Sources/PassCore/RelevantDate.swift
+++ b/Sources/PassCore/RelevantDate.swift
@@ -21,6 +21,7 @@ extension Pass {
             startDate: Date? = nil,
             endDate: Date? = nil
         ) {
+            self.date = date
             self.startDate = startDate
             self.endDate = endDate
         }


### PR DESCRIPTION
The `Pass.RelevantDate` initializer was not setting the `date` property. 